### PR TITLE
Adding a default section in the template config

### DIFF
--- a/keckdrpframework/pipeline_template/config.cfg
+++ b/keckdrpframework/pipeline_template/config.cfg
@@ -1,3 +1,4 @@
+[DEFAULT]
 #
 # Example of a default configuration
 # Original version is keckdrpframework/config/framework.cfg


### PR DESCRIPTION
Adding a `[DEFAULT]` section, as described in the [Customizing Parser Behaviour](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour) section of the manual (scroll down to `default_section`).

This fixes #28.