### PR TITLE
preserving arguments when a pre-condition fails

### DIFF
--- a/keckdrpframework/core/framework.py
+++ b/keckdrpframework/core/framework.py
@@ -210,12 +210,14 @@ class Framework(object):
                 action.output = action_output
                 if action_output is not None:
                     self.store_arguments = action_output
+                else:
+                    self.store_arguments = action.args
 
                 # Post condition
                 if pipeline.get_post_action(action_name)(action, context):
                     if not action.new_event is None:
                         # Post new event
-                        new_args = Arguments() if action_output is None else action_output
+                        new_args = self.store_arguments if action_output is None else action_output
                         self._push_event(action.new_event, new_args)
 
                     if not action.next_state is None:
@@ -232,6 +234,8 @@ class Framework(object):
                 # Failed pre-condition
                 if self.config.pre_condition_failed_stop:
                     context.state = "stop"
+                else:
+                    self.store_arguments = action.args
         except:
             self.logger.error("Exception while invoking {}".format(action_name))
             context.state = "stop"


### PR DESCRIPTION
The only change I made in this branch is a way to preserve arguments when a pre-condition fails.

The problem is this:
say we have two actions,

```event_table = {
action1: (dothis1, setstate1, action2),
action2: (dothis2, setstate2, None)
}
```

and action1 contains a pre-condition
The framework is normally set to continue with action2 if action1 fails, but action2 will inherit a empty argument.
I changed that, and I am now transferring the previous argument to the new actions.

Do you see any possible problem with this?