### PR TITLE
Switch to pip install in documentation. Ignore build directory.

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+# generated during the build
+
+build/
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,13 @@ You can download the code by cloning this repository::
 
 Change directory into the KeckDRPF directory and run::
 
-  python setup.py install
+  pip install .
+
+If you want to install the Keck DRP Framework for development purposes, you can run::
+
+  pip install -e .
+
+to install it in editable mode.
 
 Note that you will download the ``develop`` branch, which is the default branch.
 To switch to the ``master`` branch, use:


### PR DESCRIPTION
Dear maintainer(s),

while installing for the first time the framework on a Linux system (Fedora) following the [documentation](https://keckdrpframework.readthedocs.io/en/latest/#installation) I faced some issues.
- the `python setup.py install` does not allow to install if the installation is not performed with `sudo` access (as expected)
- when creating a fresh virtual environment without installing the dependencies, astropy 5.0 is downloaded and it complains about the `extension_helpers` not being installed (related to the [deprecation](https://github.com/astropy/astropy-helpers#deprecated) of the `astropy_helpers` module).

To avoid these issues I'm proposing to modify the documentation and use
```
pip install .
```
This allows to install without `sudo` rights even without virtual environment and it also manages the dependencies correctly.

In addition, I have added a `.gitignore` specific to the documentation directory.

Thanks for considering this pull request!